### PR TITLE
Dockerfile - libusb-1.0.so.0 error fix

### DIFF
--- a/Docker/Dockerfile
+++ b/Docker/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y \
     libsuitesparse-dev \
     libcgal-dev \ 
     libeigen3-dev \
+    libusb-1.0-0 \
   && rm -rf /var/lib/apt/lists/*
 
 # Install Ceres Solver


### PR DESCRIPTION
Hi, 

I'm getting the below error when I run data preparation script,
```bash
OSError: libusb-1.0.so.0: cannot open shared object file: No such file or directory
```

So, Adding libusb-1.0-0 pkg installation to the Dockerfile.

-
Jegathesan S